### PR TITLE
Complete i18n coverage for alert messages

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -4,6 +4,7 @@
 import { isMac, compareKey } from "./utils";
 import { activateGreenboardOnPlatziTest } from "./greenboard";
 import { isStudentInExam } from "./studentLocalization";
+import { t } from "./language";
 
 /**
  * @name nextQuestion
@@ -217,7 +218,7 @@ function addPlatKeyMessageToPlatziExam() {
     "StartExamOverview-list"
   )[0];
   const shortcutsInfo = document.createElement("li") as HTMLLIElement;
-  shortcutsInfo.textContent = "Puedes usar shortcuts de tu extensión Platkey.";
+  shortcutsInfo.textContent = t("examShortcutsInfo");
   overviewList.append(shortcutsInfo);
 }
 

--- a/src/deactivateShortcuts.ts
+++ b/src/deactivateShortcuts.ts
@@ -1,6 +1,8 @@
-let deactivateShortcutsMessage = `PlatKey: Para desactivar los shortcuts se recargará esta página. ${
+import { t } from "./language";
+
+let deactivateShortcutsMessage = `${t("deactivateShortcutsAlert")} ${
   window.location.pathname.startsWith("/clases/examen")
-    ? "No te preocupes, no perderás el progreso del examen."
+    ? t("deactivateShortcutsExamNote")
     : ""
 }`;
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,5 +4,14 @@
   "theme": "Theme",
   "zenmode": "Zen Mode",
   "sshmode": "SSH Mode",
-  "spotlightAlert": "PlatKey: To deactivate Spotlight, the page will reload."
+  "spotlightAlert": "PlatKey: To deactivate Spotlight, the page will reload.",
+  "greenboardWarning": "PlatKey: The Greenboard tool is meant to be used inside exams.",
+  "deactivateShortcutsAlert": "PlatKey: To deactivate shortcuts, this page will reload.",
+  "deactivateShortcutsExamNote": "Don't worry, you won't lose your exam progress.",
+  "deleteContributionConfirm": "Do you want to remove this contribution from your saved contributions?",
+  "save": "Save",
+  "saved": "Saved",
+  "highlightedClasses": "Highlighted classes",
+  "savedContributions": "Saved contributions",
+  "examShortcutsInfo": "You can use shortcuts from your Platkey extension."
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -4,5 +4,14 @@
   "theme": "Tema",
   "zenmode": "Modo Zen",
   "sshmode": "Modo SSH",
-  "spotlightAlert": "PlatKey: To deactivate Spotlight, the page will reload."
+  "spotlightAlert": "PlatKey: Para desactivar Spotlight, la página se recargará.",
+  "greenboardWarning": "PlatKey: La herramienta Greenboard está pensada para su uso dentro de exámenes.",
+  "deactivateShortcutsAlert": "PlatKey: Para desactivar los shortcuts se recargará esta página.",
+  "deactivateShortcutsExamNote": "No te preocupes, no perderás el progreso del examen.",
+  "deleteContributionConfirm": "¿Deseas eliminar este aporte de tus aportes guardados?",
+  "save": "Guardar",
+  "saved": "Guardado",
+  "highlightedClasses": "Clases destacadas",
+  "savedContributions": "Aportes guardados",
+  "examShortcutsInfo": "Puedes usar shortcuts de tu extensión Platkey."
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -4,5 +4,14 @@
   "theme": "Tema",
   "zenmode": "Modo Zen",
   "sshmode": "Modo SSH",
-  "spotlightAlert": "PlatKey: To deactivate Spotlight, the page will reload."
+  "spotlightAlert": "PlatKey: Para desativar o Spotlight, a página será recarregada.",
+  "greenboardWarning": "PlatKey: A ferramenta Greenboard foi projetada para uso durante provas.",
+  "deactivateShortcutsAlert": "PlatKey: Para desativar os atalhos, esta página será recarregada.",
+  "deactivateShortcutsExamNote": "Não se preocupe, você não perderá o progresso da prova.",
+  "deleteContributionConfirm": "Deseja remover esta contribuição das suas contribuições salvas?",
+  "save": "Salvar",
+  "saved": "Salvo",
+  "highlightedClasses": "Aulas em destaque",
+  "savedContributions": "Contribuições salvas",
+  "examShortcutsInfo": "Você pode usar atalhos da sua extensão Platkey."
 }

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,5 +1,7 @@
 import esMessages from "./locales/es.json";
 import enMessages from "./locales/en.json";
+import ptMessages from "./locales/pt.json";
+import { getLanguage, t } from "./language";
 
 type IMessages = {
   [key: string]: string;
@@ -212,8 +214,7 @@ greenboardButton.addEventListener("click", () => {
       tabs.forEach((tab) => {
         let tabUrl = tab.url as string;
         if (!tabUrl.includes("/clases/examen")) {
-          const activateGreenboardWarning = `PlatKey: La herramienta Greenboard está pensada para su uso dentro de exámenes.`;
-          window.alert(activateGreenboardWarning);
+          window.alert(t("greenboardWarning"));
           return;
         } else {
           updateGreenboardButton(!greenboard);
@@ -247,9 +248,14 @@ for (let index = 0; index < themeOptions.length; index++) {
 }
 
 function translateContent() {
-  const language = window.navigator.language.slice(0, 2);
+  const language = getLanguage();
   const elements = document.querySelectorAll("[data-i18n]");
-  messages = language === "es" ? esMessages : enMessages;
+  messages =
+    language === "es"
+      ? esMessages
+      : language === "pt"
+      ? ptMessages
+      : enMessages;
 
   elements.forEach((element) => {
     const key = element.getAttribute("data-i18n") as string;
@@ -267,7 +273,9 @@ chrome.storage.sync.get("greenboard", ({ greenboard }) => {
   chrome.tabs.query(queryDefaultOptions, (tabs) => {
     tabs.forEach((tab) => {
       let tabUrl = tab.url as string;
-      const safariPatchComponent = document.getElementById("safari-patch-greenboard") as HTMLDivElement;
+      const safariPatchComponent = document.getElementById(
+        "safari-patch-greenboard"
+      ) as HTMLDivElement;
       if (!tabUrl.includes("/clases/examen")) {
         safariPatchComponent.style.display = "none";
       }

--- a/src/saveItems.ts
+++ b/src/saveItems.ts
@@ -1,5 +1,6 @@
 import { htmlToElement } from "./utils";
 import { isStudentInClassroom } from "./studentLocalization";
+import { t } from "./language";
 
 const reportContainer = document.getElementsByClassName(
   "Header-class-report"
@@ -87,7 +88,7 @@ if (window.location.href.startsWith("https://platzi.com/clases/")) {
       url: saveContributionButton.getAttribute("data-link"),
       course: saveContributionButton.getAttribute("data-course"),
     };
-    if (saveContributionButton.textContent === "Guardar") {
+    if (saveContributionButton.textContent === t("save")) {
       // Save contribution
       chrome.storage.sync.get(
         "savedContributions",
@@ -97,13 +98,13 @@ if (window.location.href.startsWith("https://platzi.com/clases/")) {
           chrome.storage.sync.set({
             savedContributions: updatedSavedContributions,
           });
-          saveContributionButton.textContent = "Guardado";
+          saveContributionButton.textContent = t("saved");
         }
       );
     } else {
       // Delete contribution
       deleteContributionById(contributionId, () => {
-        saveContributionButton.textContent = "Guardar";
+        saveContributionButton.textContent = t("save");
       });
     }
   }
@@ -166,9 +167,9 @@ if (window.location.href.startsWith("https://platzi.com/clases/")) {
               savedContribution.id === currentContributionId
           );
           if (isSavedContribution) {
-            saveContributionButton.textContent = "Guardado";
+            saveContributionButton.textContent = t("saved");
           } else {
-            saveContributionButton.textContent = "Guardar";
+            saveContributionButton.textContent = t("save");
           }
         }
       );
@@ -239,7 +240,7 @@ if (window.location.href === "https://platzi.com/home") {
     const platziTitleParagraph = document.createElement("p");
     platziListTitleContainer.classList.add("Title");
     platziTitleLeft.classList.add("Title-left");
-    platziTitleParagraph.textContent = "Clases destacadas";
+    platziTitleParagraph.textContent = t("highlightedClasses");
     platziTitleLeft.appendChild(platziTitleParagraph);
     platziListTitleContainer.appendChild(platziTitleLeft);
     platziList.appendChild(platziListTitleContainer);
@@ -274,7 +275,7 @@ if (window.location.href === "https://platzi.com/home") {
     const platziTitleParagraphContributions = document.createElement("p");
     platziListTitleContainerContributions.classList.add("Title");
     platziTitleLeftContributions.classList.add("Title-left");
-    platziTitleParagraphContributions.textContent = "Aportes guardados";
+    platziTitleParagraphContributions.textContent = t("savedContributions");
     platziTitleLeftContributions.appendChild(platziTitleParagraphContributions);
     platziListTitleContainerContributions.appendChild(
       platziTitleLeftContributions
@@ -296,9 +297,7 @@ if (window.location.href === "https://platzi.com/home") {
     function deleteContribution(event: any) {
       event.preventDefault();
       const contributionId = event.target.getAttribute("data-id");
-      let confirm = window.confirm(
-        "¿Deseas eliminar este aporte de tus aportes guardados?"
-      );
+      let confirm = window.confirm(t("deleteContributionConfirm"));
       if (confirm) {
         deleteContributionById(contributionId);
         const contributionCard = document.getElementById(


### PR DESCRIPTION
## Summary
- Fixes `spotlightAlert` in `es.json`/`pt.json`, which was left untranslated in English.
- Adds missing locale keys (`greenboardWarning`, `deactivateShortcutsAlert`, `deactivateShortcutsExamNote`, `deleteContributionConfirm`, `save`, `saved`, `highlightedClasses`, `savedContributions`, `examShortcutsInfo`) across `en`/`es`/`pt`.
- Routes every remaining hardcoded Spanish string (greenboard warning alert, shortcuts deactivation confirm, exam shortcuts info message, save/delete contribution labels and confirm dialog) through the existing `t()` i18n helper.
- `popup.ts`'s own `translateContent()` now uses `getLanguage()` so Portuguese speakers get translated labels too, instead of silently falling back to English.

Closes #15.

## Test plan
- [x] `npm run build` compiles without errors.
- [ ] Manual verification in Chrome/Safari with browser language set to en/es/pt (not done — no way to exercise a browser extension popup from this environment).