### PR TITLE
Rebrand PlatKey under Astronware LLC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Marcelo Arias
+Copyright (c) 2021 Astronware LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Astronware LLC
+Copyright (c) 2021-2026 Astronware LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@
 <p align="center">
   🤗 Thank you for visiting this browser extension project, help spread it by giving a star! 🌟<br />
   <br />
-  🚀 Start participing in the development of this tool in the <a href="https://github.com/360macky/platkey/discussions">Discussions section</a>!<br />
+  🚀 Start participing in the development of this tool in the <a href="https://github.com/marcelo-earth/platkey/discussions">Discussions section</a>!<br />
   <br />
-  <a href="https://github.com/360macky/PlatKey/stargazers"><img src="https://img.shields.io/github/stars/360macky/PlatKey?label=Star%20this%20repository%21&style=social" /></a><br />
+  <a href="https://github.com/marcelo-earth/PlatKey/stargazers"><img src="https://img.shields.io/github/stars/marcelo-earth/PlatKey?label=Star%20this%20repository%21&style=social" /></a><br />
   <br />
   ✅ This project has diagrams to help you understand how it works! 📌<br />
 </p>
@@ -162,13 +162,13 @@ This browser extension was made with the motive of **accelerating the speed of e
 
 ### 🦊 Development
 
-If you want the latest features of PlatKey you can install the development version following [this tutorial](https://github.com/360macky/PlatKey/blob/main/INSTALLATION.md).
+If you want the latest features of PlatKey you can install the development version following [this tutorial](https://github.com/marcelo-earth/PlatKey/blob/main/INSTALLATION.md).
 
 ## 🤲 Contributing
 
-Do you would like to contribute? Do you want to be the author of a new feature? Awesome! please fork the repository and make changes as you like. [Pull requests](https://github.com/360macky/PlatKey/pulls) are warmly welcome.
+Do you would like to contribute? Do you want to be the author of a new feature? Awesome! please fork the repository and make changes as you like. [Pull requests](https://github.com/marcelo-earth/PlatKey/pulls) are warmly welcome.
 
-Also, you can check [Issues](https://github.com/360macky/PlatKey/issues) to get any ideas on how to improve this browser extension.
+Also, you can check [Issues](https://github.com/marcelo-earth/PlatKey/issues) to get any ideas on how to improve this browser extension.
 
 ## 📃 License
 

--- a/README.md
+++ b/README.md
@@ -174,3 +174,5 @@ Also, you can check [Issues](https://github.com/marcelo-earth/PlatKey/issues) to
 
 The source code is distributed under the MIT License.
 See [`LICENSE`](./LICENSE) for more information.
+
+PlatKey is a free and open source project maintained by Astronware LLC.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "description": "Atajos de teclado, guarda clases, guarda aportes, buscador aumentado.",
   "version": "3.2",
   "manifest_version": 3,
-  "author": "Marcelo Arias",
+  "author": "Astronware LLC",
   "background": {
     "service_worker": "/dist/js/background.js"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/360macky/platkey.git"
+    "url": "git+https://github.com/marcelo-earth/platkey.git"
   },
   "keywords": [
     "Chrome",
@@ -25,7 +25,7 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/360macky/platkey/issues"
+    "url": "https://github.com/marcelo-earth/platkey/issues"
   },
   "homepage": "https://platkey.dev",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
     "Browser"
   ],
   "author": {
-    "name": "Marcelo Arias",
-    "email": "hello@marceloarias.com",
-    "url": "https://marceloarias.com"
+    "name": "Astronware LLC",
+    "url": "https://platkey.dev"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
## Summary
- Updates the LICENSE copyright holder from Marcelo Arias to Astronware LLC, extending the year range to 2021-2026.
- Updates `package.json` author metadata to Astronware LLC.
- Fixes stale `360macky` repository/bugs/README URLs to the current `marcelo-earth` GitHub handle.
- Notes in the README that PlatKey is maintained by Astronware LLC.

The MIT license text, CODE_OF_CONDUCT enforcement contact, and any other personal references were left untouched since they were out of scope for this rebrand.

## Test plan
- [x] `npm run build` compiles without errors after the metadata changes.
- [ ] N/A — this PR only touches metadata/docs, no runtime behavior changed.