### PR TITLE
Fix not-matching theme-color in Safari

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -3,6 +3,7 @@
   <head>
     <link rel="stylesheet" href="./styles/popup.css" />
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+    <meta name="theme-color" content="#121f3d" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## Summary
- Adds `<meta name="theme-color" content="#121f3d">` to `public/popup.html`. Safari uses this tag to tint the extension UI chrome around the popup; without it Safari falls back to a default color that doesn't match the popup's actual background (`--really-blue: #121f3d` in `popup.css`).

Closes #16.

## Test plan
- [x] `npm run build` compiles without errors.
- [ ] Manual verification in Safari (not done — no Safari/macOS build environment available here).