### PR TITLE
Bump PlatKey to version 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ PlatKey has a software architecture targeted to be a browser extension for the C
 
 ### ⭐️ Version Workflow
 
-The latest version of PlatKey used in production is 3.0.0. The source code you can download is the latest version of **PlatKey for Developers**. Which may contain features that are not yet available in stores, and may contain bugs.
+The source code in this repository is versioned at 4.0.0. The source code you can download is the latest version of **PlatKey for Developers**, which may contain features that are not yet available in stores, and may contain bugs.
 
 ### 📦 Architecture
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Platkey",
   "description": "Atajos de teclado, guarda clases, guarda aportes, buscador aumentado.",
-  "version": "3.2",
+  "version": "4.0",
   "manifest_version": 3,
   "author": "Marcelo Arias",
   "background": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platkey",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Platzi Multiplatform Browser Extension",
   "scripts": {
     "dev": "webpack --config webpack/webpack.dev.js --watch",


### PR DESCRIPTION
## Summary
- Bumps `package.json` to `4.0.0` and `manifest.json` to `4.0`.
- Updates the README's version workflow note accordingly.

This closes out the 3.5/4.0 checklist in #8: the `src/` folder restructure was already done, and full i18n coverage (#15) is handled in #20. The "Experimental Features panel" item from #8/#6 is intentionally left out of this PR — issue #6 has no scope/spec for what those experimental features should be, so building a panel for it now would mean guessing at requirements. Left a comment on #6 asking for more detail before it's implemented.

Depends on nothing directly, but pairs well with #20 (i18n) and #21 (rebrand) landing first.

## Test plan
- [x] `npm run build` compiles without errors.
- [ ] This PR only bumps version numbers — no runtime behavior changed, nothing to publish to stores (that step is left to the maintainer).