### PR TITLE
perf: skip next/prev class DOM lookups unless their shortcut is pressed

### DIFF
--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -102,16 +102,16 @@ function handleShortcutsOnPlatzi(event: KeyboardEvent) {
     const shiftP = event.shiftKey && compareKey(["p", "P"], event.key);
     const shiftM = event.shiftKey && compareKey(["m", "M"], event.key);
 
-    const nextClass = document.getElementsByClassName(
-      "Header-course-actions-next"
-    )[0] as HTMLElement;
     if (shiftN) {
+      const nextClass = document.getElementsByClassName(
+        "Header-course-actions-next"
+      )[0] as HTMLElement;
       nextClass.click();
     }
-    const prevClass = document.getElementsByClassName(
-      "Header-course-actions-prev"
-    )[0] as HTMLElement;
     if (shiftP) {
+      const prevClass = document.getElementsByClassName(
+        "Header-course-actions-prev"
+      )[0] as HTMLElement;
       prevClass.click();
     }
     if (shiftA) {


### PR DESCRIPTION
## Resumen
- `handleShortcutsOnPlatzi()` se ejecuta en cada evento `keydown` mientras el estudiante está en una página `/clases/`.
- Antes, en cada pulsación de tecla (sin importar cuál) se ejecutaban dos `getElementsByClassName` para ubicar los botones de clase siguiente/anterior, incluso si la tecla presionada no tenía nada que ver con esos atajos (Shift+N / Shift+P).
- Ahora esas búsquedas en el DOM solo ocurren cuando el atajo correspondiente realmente se dispara.

## Plan de pruebas
- [x] `npx tsc --noEmit` sin errores.
- [ ] Verificación manual: Shift+N y Shift+P siguen navegando entre clases igual que antes en una clase de Platzi.