### PR TITLE
perf: batch chrome.storage.sync.get calls in content and popup scripts

### DIFF
--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -300,28 +300,19 @@ const updatePlatziTheme = (theme: string) => {
 };
 
 /**
- * @description Load shortcuts.
+ * @description Load shortcuts, greenboard and theme in a single storage read.
  */
-chrome.storage.sync.get("shortcuts", ({ shortcuts }) => {
-  if (shortcuts) {
-    activateShortcutsOnPlatzi();
+chrome.storage.sync.get(
+  ["shortcuts", "greenboard", "theme"],
+  ({ shortcuts, greenboard, theme }) => {
+    if (shortcuts) {
+      activateShortcutsOnPlatzi();
+    }
+    if (greenboard) {
+      activateGreenboardOnPlatziTest();
+    } else {
+      deactivateGreenboardOnPlatziTest();
+    }
+    updatePlatziTheme(theme);
   }
-});
-
-/**
- * @description Load greenboard.
- */
-chrome.storage.sync.get("greenboard", ({ greenboard }) => {
-  if (greenboard) {
-    activateGreenboardOnPlatziTest();
-  } else {
-    deactivateGreenboardOnPlatziTest();
-  }
-});
-
-/**
- * @description Load theme.
- */
-chrome.storage.sync.get("theme", ({ theme }) => {
-  updatePlatziTheme(theme);
-});
+);

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -130,22 +130,18 @@ function changeTheme(theme: string) {
   });
 }
 
-chrome.storage.sync.get("shortcuts", ({ shortcuts }) => {
-  updateShortcutsButton(shortcuts);
-});
-chrome.storage.sync.get("greenboard", ({ greenboard }) => {
-  updateGreenboardButton(greenboard);
-});
-chrome.storage.sync.get("spotlight", ({ spotlight }) => {
-  updateSpotlightButton(spotlight);
-});
-
-chrome.storage.sync.get("theme", ({ theme }) => {
-  for (let index = 0; index < themeOptions.length; index++) {
-    let themeOption = themeOptions[index];
-    themeOption.checked = themeOption.id == `radio-${theme}`;
+chrome.storage.sync.get(
+  ["shortcuts", "greenboard", "spotlight", "theme"],
+  ({ shortcuts, greenboard, spotlight, theme }) => {
+    updateShortcutsButton(shortcuts);
+    updateGreenboardButton(greenboard);
+    updateSpotlightButton(spotlight);
+    for (let index = 0; index < themeOptions.length; index++) {
+      let themeOption = themeOptions[index];
+      themeOption.checked = themeOption.id == `radio-${theme}`;
+    }
   }
-});
+);
 
 shortcutsButton.addEventListener("click", () => {
   chrome.storage.sync.get("shortcuts", ({ shortcuts }) => {
@@ -269,16 +265,14 @@ function translateContent() {
 window.addEventListener("load", translateContent);
 
 // Safari patch for window.alert bug
-chrome.storage.sync.get("greenboard", ({ greenboard }) => {
-  chrome.tabs.query(queryDefaultOptions, (tabs) => {
-    tabs.forEach((tab) => {
-      let tabUrl = tab.url as string;
-      const safariPatchComponent = document.getElementById(
-        "safari-patch-greenboard"
-      ) as HTMLDivElement;
-      if (!tabUrl.includes("/clases/examen")) {
-        safariPatchComponent.style.display = "none";
-      }
-    });
+chrome.tabs.query(queryDefaultOptions, (tabs) => {
+  tabs.forEach((tab) => {
+    let tabUrl = tab.url as string;
+    const safariPatchComponent = document.getElementById(
+      "safari-patch-greenboard"
+    ) as HTMLDivElement;
+    if (!tabUrl.includes("/clases/examen")) {
+      safariPatchComponent.style.display = "none";
+    }
   });
 });


### PR DESCRIPTION
## Resumen
- `content.ts` hacía tres llamadas separadas a `chrome.storage.sync.get` (shortcuts, greenboard, theme) en cada carga de página; `popup.ts` hacía cuatro (shortcuts, greenboard, spotlight, theme) más una quinta redundante en el parche de Safari.
- Cada llamada implica un viaje de ida y vuelta asíncrono al backend de storage de la extensión. Ahora se agrupan en una sola llamada por archivo usando un arreglo de claves.
- También se eliminó una lectura de `greenboard` en el bloque del parche de Safari en `popup.ts` cuyo valor nunca se usaba dentro del callback (solo se necesitaba `chrome.tabs.query`).

## Plan de pruebas
- [x] `npx tsc --noEmit` sin errores.
- [ ] Verificación manual: al abrir el popup, los tres botones (shortcuts, greenboard, spotlight) y el tema seleccionado reflejan el estado guardado correctamente; al cargar una página de Platzi, shortcuts/greenboard/tema se activan según lo esperado.