### PR TITLE
a11y: restore visible keyboard focus indicators in the popup

### DIFF
--- a/public/styles/popup.css
+++ b/public/styles/popup.css
@@ -190,8 +190,13 @@ h3 {
   font-size: 1rem;
 }
 
-.pkey__form-label-control:focus-within {
+.pkey__radio:focus-visible + .pkey__form-label-control {
   color: var(--skyblue);
+}
+
+.pkey__radio:focus-visible {
+  outline: 2px solid var(--skyblue);
+  outline-offset: 2px;
 }
 
 .pkey__radio {
@@ -259,6 +264,11 @@ button {
   border: none;
   background: #ffffff;
   cursor: pointer;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--skyblue);
+  outline-offset: 2px;
 }
 
 .hidden {


### PR DESCRIPTION
## Resumen
- Todos los `<button>` del popup tenían `outline: none` sin ningún reemplazo, así que un usuario navegando con teclado no tenía forma de ver qué control tenía el foco al usar Tab.
- Los radios de tema tenían el mismo problema, agravado por una regla muerta: `.pkey__form-label-control:focus-within` nunca se dispara porque el `<label>` es hermano del `<input>`, no su contenedor.
- Se agrega un contorno `:focus-visible` (usando el acento `--skyblue` ya existente) en botones y en los radios, y se corrige el resaltado del label para que reaccione al foco real del input mediante el selector de hermano adyacente (`+`).

## Plan de pruebas
- [x] Cambio puro de CSS, no requiere `tsc`.
- [ ] Verificación manual: al navegar el popup con Tab, cada botón y cada radio de tema muestra un contorno visible.