### PR TITLE
a11y: declare and sync the popup's document language

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <link rel="stylesheet" href="./styles/popup.css" />
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -246,6 +246,7 @@ for (let index = 0; index < themeOptions.length; index++) {
 function translateContent() {
   const language = getLanguage();
   const elements = document.querySelectorAll("[data-i18n]");
+  document.documentElement.lang = language;
   messages =
     language === "es"
       ? esMessages


### PR DESCRIPTION
## Resumen
- `<html>` en `popup.html` no tenía atributo `lang`, pese a que el popup se traduce en tiempo de ejecución a inglés, español o portugués según el idioma del navegador.
- Sin `lang`, los lectores de pantalla no tienen forma de saber qué voz/pronunciación usar para el contenido.
- Se agrega `lang="en"` como valor por defecto en el markup, y `translateContent()` en `popup.ts` ahora también actualiza `document.documentElement.lang` al idioma detectado, en el mismo lugar donde ya se resuelven los mensajes traducidos.

## Plan de pruebas
- [x] `npx tsc --noEmit` sin errores.
- [ ] Verificación manual: cambiar el idioma del navegador y confirmar (por ejemplo con las devtools) que `document.documentElement.lang` refleja "es"/"pt"/"en" según corresponda al abrir el popup.