### PR TITLE
a11y: add accessible names to icon-only save/delete buttons

### DIFF
--- a/src/features/saveItems/saveItems.ts
+++ b/src/features/saveItems/saveItems.ts
@@ -58,12 +58,14 @@ if (window.location.href.startsWith("https://platzi.com/clases/")) {
         );
         chrome.storage.sync.set({ classlist: updatedClassList });
         saveClassButton.style.filter = "";
+        saveClassButton.setAttribute("aria-pressed", "false");
       } else {
         // Highlight Platzi class.
         let updatedClassList = classlist;
         classlist[classlist.length] = platziClass;
         chrome.storage.sync.set({ classlist: updatedClassList });
         saveClassButton.style.filter = "sepia(1)";
+        saveClassButton.setAttribute("aria-pressed", "true");
       }
     });
   }
@@ -201,6 +203,11 @@ if (window.location.href.startsWith("https://platzi.com/clases/")) {
 
     const highlightClassButton = document.createElement("button");
     highlightClassButton.id = "save-class-button";
+    highlightClassButton.setAttribute("aria-label", t("highlightClass"));
+    highlightClassButton.setAttribute(
+      "aria-pressed",
+      isClassHighlighted ? "true" : "false"
+    );
     if (isClassHighlighted) {
       highlightClassButton.style.filter = "sepia(1)";
     }
@@ -312,7 +319,7 @@ if (window.location.href === "https://platzi.com/home") {
             </div>
             <div style="color: #ffffff; margin-bottom: 1rem; width: 12rem">${savedContribution.textPreview}...</div>
             <div class="learningPathCard-bottom" style="width: 12rem"><span>${savedContribution.course}</span></div>
-            <button type="button" class="closeNote" id="delete-contribution" data-id="${savedContribution.id}" style="align-self: end; background-color: #121f3d; border-radius: 0.4rem; border: 0; height: 1.6rem; width: 1.6rem; cursor: pointer; opacity: 0;">
+            <button type="button" class="closeNote" id="delete-contribution" data-id="${savedContribution.id}" aria-label="${t("deleteContribution")}" style="align-self: end; background-color: #121f3d; border-radius: 0.4rem; border: 0; height: 1.6rem; width: 1.6rem; cursor: pointer; opacity: 0;">
               <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="xmark" class="svg-inline--fa fa-xmark " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" data-id="${savedContribution.id}"><path data-id="${savedContribution.id}" fill="#33b1ff" d="M310.6 361.4c12.5 12.5 12.5 32.75 0 45.25C304.4 412.9 296.2 416 288 416s-16.38-3.125-22.62-9.375L160 301.3L54.63 406.6C48.38 412.9 40.19 416 32 416S15.63 412.9 9.375 406.6c-12.5-12.5-12.5-32.75 0-45.25l105.4-105.4L9.375 150.6c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L160 210.8l105.4-105.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-105.4 105.4L310.6 361.4z"></path></svg></button>
           </div></a>`) as HTMLElement;
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -11,6 +11,8 @@
   "deleteContributionConfirm": "Do you want to remove this contribution from your saved contributions?",
   "save": "Save",
   "saved": "Saved",
+  "highlightClass": "Highlight this class",
+  "deleteContribution": "Delete contribution",
   "highlightedClasses": "Highlighted classes",
   "savedContributions": "Saved contributions",
   "examShortcutsInfo": "You can use shortcuts from your Platzi Extension."

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -11,6 +11,8 @@
   "deleteContributionConfirm": "¿Deseas eliminar este aporte de tus aportes guardados?",
   "save": "Guardar",
   "saved": "Guardado",
+  "highlightClass": "Destacar esta clase",
+  "deleteContribution": "Eliminar aporte",
   "highlightedClasses": "Clases destacadas",
   "savedContributions": "Aportes guardados",
   "examShortcutsInfo": "Puedes usar shortcuts de tu extensión Platzi Extension."

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -11,6 +11,8 @@
   "deleteContributionConfirm": "Deseja remover esta contribuição das suas contribuições salvas?",
   "save": "Salvar",
   "saved": "Salvo",
+  "highlightClass": "Destacar esta aula",
+  "deleteContribution": "Excluir contribuição",
   "highlightedClasses": "Aulas em destaque",
   "savedContributions": "Contribuições salvas",
   "examShortcutsInfo": "Você pode usar atalhos da sua extensão Platzi Extension."


### PR DESCRIPTION
## Resumen
- El botón para destacar una clase y el botón "eliminar aporte" (ícono X) solo contienen un SVG, sin texto, `aria-label` ni `title`, así que un lector de pantalla no tiene forma de anunciar qué hace cada control.
- Se agrega `aria-label` a ambos, usando el sistema de i18n ya existente (nuevas claves `highlightClass` / `deleteContribution` en en/es/pt) en lugar de texto fijo.
- El botón de destacar clase ahora también expone `aria-pressed`, sincronizado con el mismo toggle que ya cambia el filtro sepia visualmente.

## Plan de pruebas
- [x] `npx tsc --noEmit` sin errores.
- [ ] Verificación manual con un lector de pantalla: ambos botones anuncian una etiqueta descriptiva, y el botón de destacar clase reporta su estado presionado/no presionado.