### PR TITLE
fix: wire the delete-contribution button to its click handler

### DIFF
--- a/src/features/saveItems/saveItems.ts
+++ b/src/features/saveItems/saveItems.ts
@@ -316,8 +316,9 @@ if (window.location.href === "https://platzi.com/home") {
               <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="xmark" class="svg-inline--fa fa-xmark " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" data-id="${savedContribution.id}"><path data-id="${savedContribution.id}" fill="#33b1ff" d="M310.6 361.4c12.5 12.5 12.5 32.75 0 45.25C304.4 412.9 296.2 416 288 416s-16.38-3.125-22.62-9.375L160 301.3L54.63 406.6C48.38 412.9 40.19 416 32 416S15.63 412.9 9.375 406.6c-12.5-12.5-12.5-32.75 0-45.25l105.4-105.4L9.375 150.6c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L160 210.8l105.4-105.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-105.4 105.4L310.6 361.4z"></path></svg></button>
           </div></a>`) as HTMLElement;
 
-        const deleteContribution = contribution.children[0].children[3] as any;
-        deleteContribution.onclick = deleteContribution;
+        const deleteContributionButton = contribution.children[0]
+          .children[3] as any;
+        deleteContributionButton.onclick = deleteContribution;
 
         classItemsContributions.appendChild(contribution);
         platziListContributions.insertAdjacentElement(


### PR DESCRIPTION
## Resumen
- Encontrado mientras se agregaban etiquetas accesibles a este mismo botón (ver #31): dentro de `loadPlatziHighlights()`, una constante local llamada `deleteContribution` (el elemento del botón) tapaba a la función `deleteContribution()` definida antes en el mismo closure.
- `deleteContribution.onclick = deleteContribution;` terminaba asignando el botón como su propio manejador de clic, no la función real, así que hacer clic en "eliminar" sobre un aporte guardado no hacía nada.
- Se renombra la variable local a `deleteContributionButton` para que `onclick` apunte a la función correcta.

## Plan de pruebas
- [x] `npx tsc --noEmit` sin errores.
- [ ] Verificación manual: en la página de inicio de Platzi, con al menos un aporte guardado, el botón de eliminar (ícono X) debe pedir confirmación y quitar la tarjeta.