### PR TITLE
a11y: reveal the delete-contribution button on keyboard focus too

### DIFF
--- a/public/styles/page.css
+++ b/public/styles/page.css
@@ -6,7 +6,8 @@
   display: flex;
 }
 
-.learningPathCard:hover .closeNote {
+.learningPathCard:hover .closeNote,
+.closeNote:focus-visible {
   opacity: 100 !important;
 }
 


### PR DESCRIPTION
## Resumen
- `.closeNote` (el botón "x" para eliminar un aporte guardado) tiene `opacity: 0` por defecto y solo se revelaba mediante `.learningPathCard:hover`, una regla que nunca aplica en navegación exclusivamente por teclado.
- Un usuario que navega con Tab podía llegar a enfocar un control invisible y sin ninguna pista visual.
- Se agrega una regla `:focus-visible` sobre el propio botón para que también se revele al recibir foco de teclado, no solo con hover del mouse.

## Plan de pruebas
- [x] Cambio puro de CSS, no requiere `tsc`.
- [ ] Verificación manual: en la página de inicio de Platzi con al menos un aporte guardado, navegar con Tab hasta el botón "x" y confirmar que se hace visible al enfocarlo.