### PR TITLE
a11y: label the greenboard color picker and localize its controls

### DIFF
--- a/src/features/greenboard/greenboard.ts
+++ b/src/features/greenboard/greenboard.ts
@@ -1,4 +1,5 @@
 import { getScriptOrStylesheet, htmlToElement } from "../../shared/utils";
+import { t } from "../../i18n/language";
 
 /**
  * @name activateGreenboardOnPlatziTest
@@ -18,16 +19,15 @@ export function activateGreenboardOnPlatziTest() {
               type="color"
               name="strokeStyle"
               value="#98ca3f"
-              alt="Elegir color"
-              title="Elegir color"
+              aria-label="${t("chooseColor")}"
+              title="${t("chooseColor")}"
             >
             <button
               id="pkey__clearButton"
               class="clearButton"
-              alt="Limpiar"
-              title="Limpiar"
+              title="${t("clearCanvas")}"
             >
-              Limpiar
+              ${t("clearCanvas")}
             </button>
         </section>
     </div>`);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -13,5 +13,7 @@
   "saved": "Saved",
   "highlightedClasses": "Highlighted classes",
   "savedContributions": "Saved contributions",
-  "examShortcutsInfo": "You can use shortcuts from your Platzi Extension."
+  "examShortcutsInfo": "You can use shortcuts from your Platzi Extension.",
+  "chooseColor": "Choose color",
+  "clearCanvas": "Clear"
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -13,5 +13,7 @@
   "saved": "Guardado",
   "highlightedClasses": "Clases destacadas",
   "savedContributions": "Aportes guardados",
-  "examShortcutsInfo": "Puedes usar shortcuts de tu extensión Platzi Extension."
+  "examShortcutsInfo": "Puedes usar shortcuts de tu extensión Platzi Extension.",
+  "chooseColor": "Elegir color",
+  "clearCanvas": "Limpiar"
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -13,5 +13,7 @@
   "saved": "Salvo",
   "highlightedClasses": "Aulas em destaque",
   "savedContributions": "Contribuições salvas",
-  "examShortcutsInfo": "Você pode usar atalhos da sua extensão Platzi Extension."
+  "examShortcutsInfo": "Você pode usar atalhos da sua extensão Platzi Extension.",
+  "chooseColor": "Escolher cor",
+  "clearCanvas": "Limpar"
 }


### PR DESCRIPTION
## Resumen
- El `<input type="color">` del Greenboard solo tenía `alt="Elegir color"`, pero `alt` no es un atributo válido fuera de `<img>`/`<input type="image">`, así que el selector de color no tenía nombre accesible para tecnología asistiva.
- Se reemplaza por `aria-label` (se conserva `title` para el tooltip del mouse).
- De paso, se enruta tanto la etiqueta del selector de color como el texto del botón "Limpiar" (antes fijos en español) a través del helper de i18n `t()` ya existente (nuevas claves `chooseColor` / `clearCanvas` en en/es/pt), consistente con el resto de la extensión multi-idioma.

## Plan de pruebas
- [x] `npx tsc --noEmit` sin errores.
- [ ] Verificación manual: activar Greenboard en un examen de Platzi y confirmar que el selector de color y el botón "Limpiar" siguen funcionando y muestran el texto correcto según el idioma del navegador.