### PR TITLE
Add Light Mode theme option

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -120,6 +120,23 @@
               SSH Mode
             </label>
           </div>
+          <div class="pkey__panel__theme-option">
+            <input
+              type="radio"
+              name="pkey__radio"
+              class="pkey__radio"
+              data-radio="light"
+              id="radio-light"
+            />
+            <label
+              class="pkey__form-label-control"
+              for="radio-light"
+              title="Tema Light Mode"
+              data-i18n="lightmode"
+            >
+              Light Mode
+            </label>
+          </div>
         </div>
       </div>
       <div class="pkey__panel-component">

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -288,13 +288,16 @@ const updatePlatziTheme = (theme: string) => {
   appendStylesheet(theme);
   switch (theme) {
     case "zen":
-      removeElementsIfExists(["ssh"]);
+      removeElementsIfExists(["ssh", "light"]);
       break;
     case "ssh":
-      removeElementsIfExists(["zen"]);
+      removeElementsIfExists(["zen", "light"]);
+      break;
+    case "light":
+      removeElementsIfExists(["zen", "ssh"]);
       break;
     default:
-      removeElementsIfExists(["zen", "ssh"]);
+      removeElementsIfExists(["zen", "ssh", "light"]);
       break;
   }
 };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -4,6 +4,7 @@
   "theme": "Theme",
   "zenmode": "Zen Mode",
   "sshmode": "SSH Mode",
+  "lightmode": "Light Mode",
   "spotlightAlert": "Platzi Extension: To deactivate Spotlight, the page will reload.",
   "greenboardWarning": "Platzi Extension: The Greenboard tool is meant to be used inside exams.",
   "deactivateShortcutsAlert": "Platzi Extension: To deactivate shortcuts, this page will reload.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -4,6 +4,7 @@
   "theme": "Tema",
   "zenmode": "Modo Zen",
   "sshmode": "Modo SSH",
+  "lightmode": "Modo Claro",
   "spotlightAlert": "Platzi Extension: Para desactivar Spotlight, la página se recargará.",
   "greenboardWarning": "Platzi Extension: La herramienta Greenboard está pensada para su uso dentro de exámenes.",
   "deactivateShortcutsAlert": "Platzi Extension: Para desactivar los shortcuts se recargará esta página.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -4,6 +4,7 @@
   "theme": "Tema",
   "zenmode": "Modo Zen",
   "sshmode": "Modo SSH",
+  "lightmode": "Modo Claro",
   "spotlightAlert": "Platzi Extension: Para desativar o Spotlight, a página será recarregada.",
   "greenboardWarning": "Platzi Extension: A ferramenta Greenboard foi projetada para uso durante provas.",
   "deactivateShortcutsAlert": "Platzi Extension: Para desativar os atalhos, esta página será recarregada.",


### PR DESCRIPTION
## Summary
- Adds a fourth theme option, **Light Mode**, next to Normal, Zen Mode and SSH Mode in the popup
- Wires it up in the content script so selecting it loads `light.css` (already published in `360macky/platzikey-themes`, but never wired into the extension) and removes any previously injected zen/ssh stylesheet
- Adds the `lightmode` translation key to the en, es and pt locales

## Test plan
- [ ] `npm run build` and load the unpacked extension
- [ ] Open the popup on a Platzi Test page, select Light Mode, confirm the page switches to a white/black theme
- [ ] Switch between Normal, Zen Mode, SSH Mode and Light Mode and confirm only one stylesheet is active at a time
- [ ] Confirm the label is translated correctly in en/es/pt