### PR TITLE
Update domain references to platzi-extensions.vercel.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 </p>
 
 <p align="center">
-  <a href="https://platziextension.dev">www.platziextension.dev</a>
+  <a href="https://platzi-extensions.vercel.app">platzi-extensions.vercel.app</a>
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
   ],
   "author": {
     "name": "Astronware LLC",
-    "url": "https://platziextension.dev"
+    "url": "https://platzi-extensions.vercel.app"
   },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/marcelo-earth/platzi-extensions/issues"
   },
-  "homepage": "https://platziextension.dev",
+  "homepage": "https://platzi-extensions.vercel.app",
   "devDependencies": {
     "@types/chrome": "^0.0.213",
     "copy-webpack-plugin": "^11.0.0",

--- a/public/popup.html
+++ b/public/popup.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <div class="pkey__title-container">
-      <a href="https://platziextension.dev" target="_blank">
+      <a href="https://platzi-extensions.vercel.app" target="_blank">
         <img
           src="./images/logo.svg"
           alt="Platzi Extensions"
@@ -48,7 +48,7 @@
         </button>
       </div>
       <div class="pkey__panel-dual-component">
-        <a href="https://platziextension.dev" target="_blank">
+        <a href="https://platzi-extensions.vercel.app" target="_blank">
           <div class="pkey__panel-side-component">
             <img
               src="./images/info.svg"
@@ -57,7 +57,7 @@
             />
           </div>
         </a>
-        <a href="https://platziextension.dev/love" target="_blank">
+        <a href="https://platzi-extensions.vercel.app/love" target="_blank">
           <div class="pkey__panel-side-component">
             <img
               src="./images/heart.svg"


### PR DESCRIPTION
## Summary
- Replace the retired `platziextension.dev` domain with `https://platzi-extensions.vercel.app` in `package.json` (author URL, homepage), `README.md`, and `public/popup.html` outbound links

## Test plan
- [ ] Build the extension (`npm run build`) and confirm the popup links open the new domain